### PR TITLE
feat: impl new algo for expand vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,24 @@ postcss([
 .Button {
   color: var(--color);
   font-size: var(--size);
+  box-sizing: border-box;
 }
 ```
 
 #### output:
 
+Split rules from other chunks of theme to extra selectors for order to reduce the specificity.
+
 ```css
-.Theme_color_default.Theme_size_default .Button {
+.Button {
+  box-sizing: border-box;
+}
+
+.Theme_color_default .Button {
   color: #fff;
+}
+
+.Theme_size_default .Button {
   font-size: 10px;
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,7 +74,7 @@ export default plugin<ThemeFoldOptions>('postcss-theme-fold', (options = {} as a
             while ((executed = VARIABLE_USE_RE.exec(node.value)) !== null) {
               // Avoid infinite loops with zero-width matches.
               if (executed.index === VARIABLE_USE_RE.lastIndex) {
-                VARIABLE_USE_RE.lastIndex++;
+                VARIABLE_USE_RE.lastIndex++
               }
               variables.push(executed[1])
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { getFromCache } from './cache'
 import { THEME_SELECTOR_RE, VARIABLE_USE_RE, VARIABLE_FULL_RE } from './shared'
 import { StringStringMap } from './extract-theme-variables'
 import { extractVariablesFromThemes } from './extract-variables-from-themes'
+import { uniq } from './uniq'
 
 function getVariableMeta(
   themeMap: StringStringMap,
@@ -20,6 +21,10 @@ function getVariableMeta(
 
   return variableMeta
 }
+
+type RuleProps = { [key in string]: { selectors: string[], nodes: ChildNode[] } }
+type AnyDict = { [key in string]: any }
+type EnhancedChildNode = ChildNode & { processed: boolean }
 
 type ThemeFoldOptions = {
   /**
@@ -56,11 +61,12 @@ export default plugin<ThemeFoldOptions>('postcss-theme-fold', (options = {} as a
       const rules = []
 
       for (const theme of themesSet) {
-        let themeScopeSelector = ''
         const nextRule = rule.clone()
+        const processedProps: RuleProps = {}
+        const themeSelectors: AnyDict = {}
 
-        // Cast to `ChildNode` cuz before we already check nodes for undefined.
-        for (const node of (nextRule.nodes as ChildNode[])) {
+        // Cast to `EnhancedChildNode` cuz before we already check nodes for undefined.
+        for (const node of (nextRule.nodes as EnhancedChildNode[])) {
           if (node.type === 'decl') {
             let executed = null
             const variables = []
@@ -77,43 +83,70 @@ export default plugin<ThemeFoldOptions>('postcss-theme-fold', (options = {} as a
               const { value, themeSelector } = getVariableMeta(theme, variable)
               // When variable not found then skip this rule for processing.
               if (value !== '') {
+                // Mark node as processed and remove them later.
+                node.processed = true
                 node.value = node.value.replace(VARIABLE_FULL_RE, value)
-                // Prevent duplicate theme selectors.
-                if (!themeScopeSelector.includes(themeSelector)) {
-                  themeScopeSelector += themeSelector
-                }
+                const nextProp = processedProps[node.prop] || { selectors: [], nodes: [] }
+                nextProp.selectors.push(themeSelector)
+                nextProp.nodes.push(node)
+                processedProps[node.prop] = nextProp
               }
             }
           }
         }
 
-        // When `themeScopeSelector` is empty this means selector not have css variables from theme,
+        // When `processedProps` is empty this means rule not have css variables from theme,
         // and we not cache this in `processedSelectorsSet` cuz him may be declared in other place.
-        if (themeScopeSelector === '') {
+        if (Object.keys(processedProps).length === 0) {
           rules.push(nextRule)
           return
         }
 
-        // Add theme scopes for each selector.
-        nextRule.selectors = nextRule.selectors
-          .map((selector) => {
-            // Only work for single root selector, e.g. `.utilityfocus .Button {...}`.
-            const maybeGlobalSelector = (options.globalSelectors || []).find((globalSelector) => {
-              if (selector.startsWith(globalSelector)) {
-                return globalSelector
-              }
-            })
-            if (maybeGlobalSelector === undefined) {
-              return `${themeScopeSelector} ${selector}`
-            }
-            const nextSelector = selector.replace(maybeGlobalSelector, '')
-            return `${maybeGlobalSelector} ${themeScopeSelector} ${nextSelector}`
-          })
-
         // Prevent duplicate already processed selectors.
         if (!processedSelectorsSet.has(nextRule.selector)) {
           processedSelectorsSet.add(nextRule.selector)
-          rules.push(nextRule)
+          // Remove already processed nodes from base rule.
+          nextRule.nodes = (nextRule.nodes as EnhancedChildNode[]).filter((node) => !node.processed)
+          if (nextRule.nodes.length > 0) {
+            // Push nextRule before forkedRule,
+            // cuz them maybe contains not processed selectors.
+            rules.push(nextRule)
+          }
+        }
+
+        // Create shape with unique theme selectors and nodes.
+        for (const key in processedProps) {
+          const selector = uniq(processedProps[key].selectors).join('')
+          const nodes = uniq(processedProps[key].nodes)
+          if (themeSelectors[selector] === undefined) {
+            themeSelectors[selector] = []
+          }
+          themeSelectors[selector].push(...nodes)
+        }
+
+        for (const themeSelector in themeSelectors) {
+          const forkedRule = rule.clone()
+          // Add extra theme selectors for forked rule.
+          forkedRule.selectors = forkedRule.selectors
+            .map((selector) => {
+              // Only work for single root selector, e.g. `.utilityfocus .Button {...}`.
+              const maybeGlobalSelector = (options.globalSelectors || []).find((globalSelector) => {
+                if (selector.startsWith(globalSelector)) {
+                  return globalSelector
+                }
+              })
+              if (maybeGlobalSelector === undefined) {
+                return `${themeSelector} ${selector}`
+              }
+              const nextSelector = selector.replace(maybeGlobalSelector, '')
+              return `${maybeGlobalSelector} ${themeSelector} ${nextSelector}`
+            })
+          forkedRule.nodes = themeSelectors[themeSelector]
+          // Prevent duplicate already processed selectors.
+          if (!processedSelectorsSet.has(forkedRule.selector)) {
+            processedSelectorsSet.add(forkedRule.selector)
+            rules.push(forkedRule)
+          }
         }
       }
 

--- a/src/uniq.ts
+++ b/src/uniq.ts
@@ -1,0 +1,3 @@
+export function uniq<T>(array: T[]): T[] {
+  return Array.from(new Set(array))
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -34,7 +34,10 @@ describe('postcss-theme-fold', () => {
   test('should mix theme selectors for a few variables', async () => {
     await run(
       '.Button { font-size: var(--size-1); border-radius: var(--cosmetic-1) }',
-      '.Theme_size_a.Theme_cosmetic_a .Button { font-size: 10px; border-radius: 2px }',
+      `
+        .Theme_size_a .Button { font-size: 10px }
+        .Theme_cosmetic_a .Button { border-radius: 2px }
+      `,
     )
   })
 
@@ -108,6 +111,17 @@ describe('postcss-theme-fold', () => {
     await run(
       '.Button { height: var(--size-1); width: var(--size-2); }',
       '.Theme_size_a .Button { height: 10px; width: 20px; }',
+    )
+  })
+
+  test('should move expanded rules to extra selector', async () => {
+    await run(
+      '.Button { color: var(--color-1); box-sizing: border-box; }',
+      `
+        .Button { box-sizing: border-box; }
+        .Theme_color_a .Button { color: #fff; }
+        .Theme_color_b .Button { color: #000; }
+      `,
     )
   })
 })


### PR DESCRIPTION
resolve #20

## Что поменялось

Изменился алгоритм раскрытия css-переменных, в следствии чего, часть селекторов должна быть разгружена и иметь чуть меньшую специфичность чем до этого.

Это позволит не усиливать дополнительно селекторы на сервисах, например когда в кнопке был ресет для отступов, а на сервисе был микс с отступом у кнопки, в итоге этот микс не работал, т.к. базовый селектор имел очень большую специфичность.

Как было до:

```css
/* Input */
.Button {
  box-sizing: border-box;
  color: var(--color-1);
}

/* Output */
.Theme_color_a .Button {
  box-sizing: border-box;
  color: #fff;
}
```

Как стало:

```css
/* Input */
.Button {
  box-sizing: border-box;
  color: var(--color-1);
}

/* Output */
.Button {
  box-sizing: border-box;
}

.Theme_color_a .Button {
  color: #fff;
}
```

## TODO

- [x] Обновить в readme пример с итогом работы
