### PR TITLE
add support override selectors

### DIFF
--- a/src/processed-map.ts
+++ b/src/processed-map.ts
@@ -1,0 +1,45 @@
+import { ChildNode } from 'postcss'
+
+export type ProcessedProps = {
+    value: string;
+    prop: string;
+}
+
+export function addValueToMap(map: Map<string, ProcessedProps[]>, selector: string, value: ProcessedProps): void {
+    const currentValue = map.get(selector);
+    if (currentValue) {
+        map.set(selector, [
+            ...currentValue,
+            value
+        ]);
+    } else {
+        map.set(selector, [value])
+    }
+}
+
+export function removeValueFromMap(map: Map<string, ProcessedProps[]>, selector: string, value: ProcessedProps): void {
+    const currentValue = map.get(selector);
+    if (!currentValue)
+        return;
+
+    const nextValue = currentValue.filter(item => {
+        return item.prop !== value.prop || item.value !== value.value;
+    })
+    if (nextValue.length === 0) {
+        map.delete(selector);
+    } else {
+        map.set(selector, nextValue);
+    }
+}
+
+export function removeNodesFromMap(map: Map<string, ProcessedProps[]>, nodes: ChildNode[]): void {
+    nodes.forEach(node => {
+        if (node.type === 'decl' && node.parent.type === 'rule') {
+            removeValueFromMap(map, node.parent.selector, {
+                value: node.value,
+                prop: node.prop
+            });
+        }
+    })
+}
+

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,9 @@
 import postcssThemeFold from '../src/index'
+
+jest.mock('../src/cache', () => ({
+  getFromCache: (a: Function) => (a())
+}))
+
 import { configureRunner } from './__internal/runner'
 import { resolveFixture } from './__internal/fixture-resolver'
 
@@ -18,6 +23,7 @@ describe('postcss-theme-fold', () => {
   let errorLog:() => void;
 
   beforeAll(() => {
+
     errorLog =  console.error;
     console.error = jest.fn().mockImplementation(() => {});
   })

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -23,7 +23,6 @@ describe('postcss-theme-fold', () => {
   let errorLog:() => void;
 
   beforeAll(() => {
-
     errorLog =  console.error;
     console.error = jest.fn().mockImplementation(() => {});
   })
@@ -230,6 +229,13 @@ describe('postcss-theme-fold', () => {
         '.Button { color: var(--color-1); }',
         '.Button { color: #fff; }',
       )
+    })
+
+    test('should expand override selectors', async () => {
+      await run(
+        '.Button { color: var(--color-0);} @media and screen (mix-width: 500px) { .Button { padding: var(--cosmetic-1);}}',
+        '.Button { color: #fff;} @media and screen (mix-width: 500px) { .Button { padding: 2px;}}'
+    )
     })
   })
 


### PR DESCRIPTION
Fix: https://github.com/yarastqt/postcss-theme-fold/issues/29

## Как это работает

В момент обработки узлов мы запоминаем селектор и свойство со значением в словарь.
После обработки всех узлов у нас появляется словарь вида:
```ts
`.Button` => [ {width: '10px', color: '#fff' } ]
```

И в  момент, когда мы решаем, применять ли полученное правило, мы проверяем не только обработан ли селектор, но учтены ли все измененные узлы по этому селектору, если мы какой-то пропустили – добавляем это правило тоже.

## Зачем trim()

После [обработки селекторов](https://github.com/yarastqt/postcss-theme-fold/blob/master/src/index.ts#L199-L212) `forkedRule.selector` может измениться и там появится пробел в начале.  Селектор вида `.Button` станет ` .Button`, что будет другим значением и мы не учтем нужные узлы.