### PR TITLE
feat: variables in root selector for themekit

### DIFF
--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-export const THEME_SELECTOR_RE = /^.Theme_/
+export const THEME_SELECTOR_RE = /^(.Theme_)|(:root)/
 export const VARIABLE_DECL_RE = /^--/
 export const VARIABLE_USE_RE = /var\(\s*(--[^,\s)]+)/g
 export const VARIABLE_FULL_RE = /var\((--[\w-]+)\)/

--- a/tests/__fixtures__/components/Theme/Theme_root_color_a.css
+++ b/tests/__fixtures__/components/Theme/Theme_root_color_a.css
@@ -1,0 +1,5 @@
+:root {
+  --color-0: var(--color-1);
+  --color-1: #fff;
+  --color-2: #000;
+}

--- a/tests/__fixtures__/components/Theme/Theme_root_cosmetic_a.css
+++ b/tests/__fixtures__/components/Theme/Theme_root_cosmetic_a.css
@@ -1,0 +1,4 @@
+:root {
+  --cosmetic-1: 2px;
+  --cosmetic-2: 4px;
+}

--- a/tests/__fixtures__/components/Theme/Theme_root_size_a.css
+++ b/tests/__fixtures__/components/Theme/Theme_root_size_a.css
@@ -1,0 +1,4 @@
+:root {
+  --size-1: 10px;
+  --size-2: 20px;
+}

--- a/tests/extract-theme-variables.test.ts
+++ b/tests/extract-theme-variables.test.ts
@@ -21,6 +21,20 @@ describe('extract-theme-variables', () => {
     done()
   })
 
+  test('should return themes map with expanded variables for :root selector', async (done) => {
+    const content = await readFileAsync(resolveFixture('components/Theme/Theme_root_color_a.css'), 'utf-8')
+    const variablesMap = await extractThemeVariables(content)
+    const expected = new Map([
+      [':root', new Map([
+        ['--color-0', '#fff'],
+        ['--color-1', '#fff'],
+        ['--color-2', '#000'],
+      ])],
+    ])
+    expect(variablesMap).toEqual(expected)
+    done()
+  })
+
   test('should throw error when theme contains not a variables', async () => {
     const content = await readFileAsync(resolveFixture('components/Theme/Theme_color_broken.css'), 'utf-8')
     try {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -7,6 +7,12 @@ jest.mock('../src/cache', () => ({
 import { configureRunner } from './__internal/runner'
 import { resolveFixture } from './__internal/fixture-resolver'
 
+const rootTheme = [
+  resolveFixture('components/Theme/Theme_root_color_a.css'),
+  resolveFixture('components/Theme/Theme_root_size_a.css'),
+  resolveFixture('components/Theme/Theme_root_cosmetic_a.css'),
+]
+
 const themeA = [
   resolveFixture('components/Theme/Theme_color_a.css'),
   resolveFixture('components/Theme/Theme_size_a.css'),
@@ -238,6 +244,29 @@ describe('postcss-theme-fold', () => {
     const run = configureRunner([
       postcssThemeFold({
         themes: [themeA],
+        globalSelectors: ['.utilityfocus'],
+      })
+    ])
+
+    test('should expand variables without theme selector', async () => {
+      await run(
+        '.Button { color: var(--color-1); }',
+        '.Button { color: #fff; }',
+      )
+    })
+
+    test('should expand override selectors', async () => {
+      await run(
+        '.Button { color: var(--color-0);} @media and screen (mix-width: 500px) { .Button { padding: var(--cosmetic-1);}}',
+        '.Button { color: #fff;} @media and screen (mix-width: 500px) { .Button { padding: 2px;}}'
+    )
+    })
+  })
+
+  describe('single-theme with :root selector', () => {
+    const run = configureRunner([
+      postcssThemeFold({
+        themes: [rootTheme],
         globalSelectors: ['.utilityfocus'],
       })
     ])


### PR DESCRIPTION
[themekit](https://github.com/bem/themekit) without selector option generates css with `:root` named selector
But `extractThemeVariables` ignore selectors like this and skip variables.