### PR TITLE
Preserve default value

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Postcss plugin for folding css-variables with using [whitepaper](whitepaper) des
 ## Install
 
 ```sh
-npm i -D postcss-theme-fold
+npm i -D postcss postcss-theme-fold
 ```
 
 ## Usage

--- a/package-lock.json
+++ b/package-lock.json
@@ -1061,6 +1061,12 @@
         "color-name": "^1.0.0"
       }
     },
+    "colorette": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.4.0.tgz",
+      "integrity": "sha512-Y2oEozpomLn7Q3HFP7dpww7AtMJplbM9lGZP6RDfHqmbeRjiwRg4n6VM6j4KLmRke85uWEI7JqF17f3pqdRA0g==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -4519,6 +4525,12 @@
       "dev": true,
       "optional": true
     },
+    "nanoid": {
+      "version": "3.1.30",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+      "dev": true
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
@@ -4917,13 +4929,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.24",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.24.tgz",
-      "integrity": "sha512-Xl0XvdNWg+CblAXzNvbSOUvgJXwSjmbAKORqyw9V2AlHrm1js2gFw9y3jibBAhpKZi8b5JzJCVh/FyzPsTtgTA==",
+      "version": "8.3.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.6.tgz",
+      "integrity": "sha512-wG1cc/JhRgdqB6WHEuyLTedf3KIRuD0hG6ldkFEZNCjRxiC+3i6kkWUUbiJQayP28iwG35cEmAbe98585BYV0A==",
+      "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
-        "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
+        "colorette": "^1.2.2",
+        "nanoid": "^3.1.23",
+        "source-map-js": "^0.6.2"
       }
     },
     "postcss-color-function": {
@@ -4962,7 +4975,6 @@
       "resolved": "https://registry.npmjs.org/postcss-import/-/postcss-import-12.0.1.tgz",
       "integrity": "sha512-3Gti33dmCjyKBgimqGxL3vcV8w9+bsHwO5UrBawp796+jdardbcFl4RP5w/76BwNL7aGzpKstIfF9I+kdE8pTw==",
       "requires": {
-        "postcss": "^7.0.1",
         "postcss-value-parser": "^3.2.3",
         "read-cache": "^1.0.0",
         "resolve": "^1.1.7"
@@ -4976,10 +4988,7 @@
     "postcss-simple-vars": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/postcss-simple-vars/-/postcss-simple-vars-5.0.2.tgz",
-      "integrity": "sha512-xWIufxBoINJv6JiLb7jl5oElgp+6puJwvT5zZHliUSydoLz4DADRB3NDDsYgfKVwojn4TDLiseoC65MuS8oGGg==",
-      "requires": {
-        "postcss": "^7.0.14"
-      }
+      "integrity": "sha512-xWIufxBoINJv6JiLb7jl5oElgp+6puJwvT5zZHliUSydoLz4DADRB3NDDsYgfKVwojn4TDLiseoC65MuS8oGGg=="
     },
     "postcss-value-parser": {
       "version": "3.3.1",
@@ -5566,6 +5575,12 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "source-map-js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+      "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+      "dev": true
+    },
     "source-map-resolve": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
@@ -5849,6 +5864,7 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
       "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,10 +24,13 @@
     "conventional-changelog-cli": "2.1.0",
     "jest": "24.9.0",
     "ts-jest": "24.2.0",
-    "typescript": "3.7.3"
+    "typescript": "3.7.3",
+    "postcss": "^8.0.0"
+  },
+  "peerDependencies": {
+    "postcss": "^8.0.0"
   },
   "dependencies": {
-    "postcss": "7.0.24",
     "postcss-color-function": "4.1.0",
     "postcss-import": "12.0.1",
     "postcss-simple-vars": "5.0.2"

--- a/src/extract-theme-variables.ts
+++ b/src/extract-theme-variables.ts
@@ -1,4 +1,4 @@
-import postcss from 'postcss'
+import postcss, { Root } from 'postcss'
 
 import { THEME_SELECTOR_RE, VARIABLE_DECL_RE, VARIABLE_FULL_RE } from './shared'
 
@@ -10,9 +10,9 @@ export type StringStringMap = Map<string, StringMap>
  */
 export async function extractThemeVariables(css: string): Promise<StringStringMap> {
   const variablesMap = new Map<string, StringMap>()
-  const postcssExtractThemeVariable = postcss.plugin(
-    'postcss-extract-theme-variable',
-    () => (root) => {
+  const postcssExtractThemeVariable = {
+    postcssPlugin: 'postcss-extract-theme-variable',
+    Once: (root: Root) => {
       root.walkRules(({ selector, nodes }) => {
         if (!THEME_SELECTOR_RE.test(selector) || !nodes) {
           return
@@ -28,8 +28,8 @@ export async function extractThemeVariables(css: string): Promise<StringStringMa
           }
         }
       })
-    },
-  )
+    }
+  }
 
   const processLocalVariables = () => {
     for (const [, variables] of variablesMap) {
@@ -45,7 +45,7 @@ export async function extractThemeVariables(css: string): Promise<StringStringMa
     }
   }
 
-  return postcss([postcssExtractThemeVariable()])
+  return postcss([postcssExtractThemeVariable])
     .process(css, { from: '' })
     .then(processLocalVariables)
     .then(() => variablesMap)

--- a/src/extract-variables-from-string.ts
+++ b/src/extract-variables-from-string.ts
@@ -1,0 +1,16 @@
+import { VARIABLE_USE_RE } from "./shared"
+
+export function extractVariablesFromString(value: string) {
+  let executed = null
+  const variables = []
+
+  while ((executed = VARIABLE_USE_RE.exec(value)) !== null) {
+    // Avoid infinite loops with zero-width matches.
+    if (executed.index === VARIABLE_USE_RE.lastIndex) {
+      VARIABLE_USE_RE.lastIndex++
+    }
+    variables.push(executed[1])
+  }
+
+  return variables;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { StringStringMap } from './extract-theme-variables'
 import { extractVariablesFromThemes } from './extract-variables-from-themes'
 import { uniq } from './uniq'
 import { addValueToMap, checkNodesProcessed, hasUnprocessedNodes } from './processed-map'
+import { extractVariablesFromString } from './extract-variables-from-string'
 
 function getVariableMeta(
   themeMap: StringStringMap,
@@ -139,18 +140,8 @@ export default (options: ThemeFoldOptions = { themes: [], globalSelectors: [] })
                 continue
               }
 
-              let executed = null
-              const variables = []
-              // Use this variables for debug.
-              const usedVariables = []
-
-              while ((executed = VARIABLE_USE_RE.exec(node.value)) !== null) {
-                // Avoid infinite loops with zero-width matches.
-                if (executed.index === VARIABLE_USE_RE.lastIndex) {
-                  VARIABLE_USE_RE.lastIndex++
-                }
-                variables.push(executed[1])
-              }
+              const variables = extractVariablesFromString(node.value);
+              const usedVariables = [];
 
               for (const variable of variables) {
                 // Variable absence in uniqVariables means that
@@ -160,6 +151,7 @@ export default (options: ThemeFoldOptions = { themes: [], globalSelectors: [] })
                 if (!node.processed) {
                   continue
                 }
+
                 const { value, themeSelector } = getVariableMeta(theme, variable)
                 // When variable not found then skip this rule for processing.
                 if (node.value && value !== '') {

--- a/src/processed-map.ts
+++ b/src/processed-map.ts
@@ -1,4 +1,4 @@
-import { ChildNode } from 'postcss'
+import { EnhancedChildNode } from './shared'
 
 export type ProcessedProps = {
   value: string
@@ -51,7 +51,7 @@ export function removeValueFromMap(
 
 export function checkNodesProcessed(
   map: Map<string, ProcessedProps[]>,
-  nodes: ChildNode[],
+  nodes: EnhancedChildNode[],
   themeSelector: string,
 ): void {
   nodes.forEach((node) => {
@@ -59,7 +59,7 @@ export function checkNodesProcessed(
       removeValueFromMap(map, themeSelector, {
         value: node.value,
         prop: node.prop,
-        selector: node.parent.selector.trim(),
+        selector: node.parent.selector?.trim(),
       })
     }
   })

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,4 @@
-import { ChildNode } from "postcss"
+import { ChildNode, Declaration } from "postcss"
 
 export const THEME_SELECTOR_RE = /^(.Theme_)|(:root)/
 export const VARIABLE_DECL_RE = /^--/

--- a/src/shared.ts
+++ b/src/shared.ts
@@ -1,4 +1,15 @@
+import { ChildNode } from "postcss"
+
 export const THEME_SELECTOR_RE = /^(.Theme_)|(:root)/
 export const VARIABLE_DECL_RE = /^--/
 export const VARIABLE_USE_RE = /var\(\s*(--[^,\s)]+)/g
 export const VARIABLE_FULL_RE = /var\((--[\w-]+)\)/
+
+export type EnhancedChildNode = ChildNode & {
+  processed: boolean;
+  broken: boolean;
+  original: ChildNode;
+  parent: {
+    selector: string
+  }
+}

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -369,14 +369,14 @@ describe('postcss-theme-fold', () => {
     test('should preserve original variables of elements in preserve', async () => {
       await run(
         '.Button { border: var(--size-1) solid var(--color-1); }',
-        '.Button { border: 10px solid #fff; border: var(--size-1) solid var(--color-1); }',
+        '.Button { border: 10px solid #fff; border: 10px solid var(--color-1, #fff); }',
       )
     })
 
     test('should not preserve original variables of elements in preserve', async () => {
       await run(
         '.Button { border: var(--size-1) solid var(--color-1); color: var(--color-0); }',
-        '.Button { border: 10px solid #fff; border: var(--size-1) solid var(--color-1); color: #fff; }',
+        '.Button { border: 10px solid #fff; border: 10px solid var(--color-1, #fff); color: #fff; }',
       )
     })
   })


### PR DESCRIPTION
1. Добавил сохранение дефолтных значений для Css-переменных. Это нужно, если какая-то css переменная не была установлена пользователем.
2. Вынес парсинг css-переменных в отдельную функцию.